### PR TITLE
Add strategic fallback data for the test Kanban

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -85,31 +85,39 @@ kanban/
 ```
 test/
 ├── index.html              # Version de test
-├── css/                    # CSS synchronisé avec production  
-├── js/                     # 🆕 JS avec corrections tracking statut (27/07/2025)
-│   ├── kanban-app.js       # ✅ Fix handleDragEnd() - capture oldStatus avant modification
+├── css/                    # CSS synchronisé avec production
+├── js/
+│   ├── app-initializer.js  # ✅ Point d'entrée ES module (instancie core/KanbanManager)
+│   ├── core/
+│   │   └── KanbanManager.js # ♻️ Orchestrateur principal aligné avec la prod
 │   ├── managers/
 │   │   ├── ModalManager.js # ✅ Fix tracking statut via modal avec UserActionManager
 │   │   ├── JalonManager.js # ✅ Dernières corrections édition/suppression jalons
 │   │   └── ...             # Autres managers synchronisés
-│   └── utils/
-│       ├── UserActionManager.js    # ✅ Système tracking actions utilisateur
-│       ├── NotesJsonMigrator.js    # ✅ Migration notes vers JSON
-│       └── ...                     # Autres utilitaires
+│   ├── utils/
+│   │   ├── UserActionManager.js    # ✅ Système tracking actions utilisateur
+│   │   ├── NotesJsonMigrator.js    # ✅ Migration notes vers JSON
+│   │   └── ...                     # Autres utilitaires
+│   └── kanban-app.js       # 💤 Version legacy conservée pour référence (non chargée)
 ├── 🔒 [IGNORÉ] Scripts avec identifiants # Scripts tests/API (exclus du git)
-├── fix-status-tracking.md  # 📋 Documentation corrections statut
 ├── ARCHITECTURE.md         # Documentation architecture complète
-├── CHANGELOG_2025-07-27.md # 🆕 Corrections tracking historique
-├── CHANGELOG_2025-07-20.md # Corrections critiques récentes
+├── ROADMAP.md              # Suivi des chantiers à venir
+├── REFACTORING_ARCHITECTURE.md # Centralisation des responsabilités de rendu
 └── schema.md               # Schéma base de données Grist
 ```
 
-### 🎯 Usage Actuel (Depuis 27/07/2025)
+### 🎯 Usage Actuel
 - **🔥 Environnement principal** pour développement et corrections
+- **✅ Initialisation unique** : seul `core/KanbanManager` est instancié (kanban-app.js legacy désactivé)
 - **✅ Tests automatisés** via scripts API Grist (readonly-test-suite.js)
-- **🔧 Corrections critiques** tracking historique des changements de statut  
-- **📊 Analyse données** (67 tâches, 2 jalons, 0 changements statut trackés)
+- **🔧 Corrections critiques** tracking historique des changements de statut
 - **🛡️ Sécurité** - Scripts avec identifiants exclus du repository git
+
+### 🆕 Mise à jour 2025-09-02
+- Remplacement du script legacy `kanban-app.js` par `app-initializer.js` dans `index.html`
+- Exposition directe de `window.kanbanAppInitializer` pour le debug développeur
+- Vérifications renforcées `window.grist` lors des chargements automatiques
+- Documentation interne alignée sur la nouvelle arborescence (`ROADMAP.md`, `REFACTORING_ARCHITECTURE.md`)
 
 ### Synchronisation
 - **kanban/ → test/** (27/07/2025) : Synchronisation complète pour développement

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -21,6 +21,7 @@ Refactoriser proprement l'application Kanban sans tout détruire, en corrigeant 
 - `/kanban/` : Architecture moderne avec `kanban-app.js`
 - `/test/` : Ancienne architecture avec `/core/KanbanManager.js`
 - `index.html` différents (imports, scripts, versions)
+**Avancement 2025-09-02 :** L'environnement `/test` ne charge plus `kanban-app.js` et instancie uniquement `core/KanbanManager` via `app-initializer.js` pour éviter la double initialisation.
 
 #### 3. **Cache et Versioning**
 **Problème:** Paramètres `?v=20250728-DEDUP-MODAL` obsolètes
@@ -41,6 +42,7 @@ Refactoriser proprement l'application Kanban sans tout détruire, en corrigeant 
 - [x] Correction de toutes les références `grist` → `window.grist`
 - [x] Ajout de vérifications de disponibilité de l'API
 - [x] Tests de fonctionnement en environnement Grist
+- [x] 2025-09-02 : Centralisation des gardes `window.grist` dans `AppInitializer`, `GristManager` et `HistoryManager`
 
 ### Phase 2: Unification Architecturale
 #### 2.1 Définir l'Architecture de Référence
@@ -125,6 +127,12 @@ if (typeof window.grist === 'undefined') {
 1. **Amélioration gestion d'erreurs**
 2. **Documentation architecture unifiée**
 3. **Tests automatisés**
+
+## 📝 Suivi des Mises à Jour Récentes
+
+- **2025-09-02 — Désactivation du double orchestrateur** : `test/index.html` ne référence plus `kanban-app.js` ; les helpers console pointent vers `window.kanbanAppInitializer`.
+- **2025-09-02 — Vérifications Grist consolidées** : L'auto-reload et les managers rejettent proprement les appels lorsque `window.grist` est absent.
+- **2025-09-02 — Documentation alignée** : `PROJECT_STRUCTURE.md` et la documentation `/test/` reflètent la nouvelle arborescence `js/app-initializer.js` + `core/`.
 
 ## ⚠️ Précautions
 

--- a/test/index.html
+++ b/test/index.html
@@ -540,9 +540,6 @@
   
   <!-- Gestionnaire de clics simple -->
   
-  <!-- Application Kanban modulaire -->
-  <script type="module" src="js/kanban-app.js"></script>
-  
   <!-- Initialisateur principal -->
   <script type="module" src="js/app-initializer.js"></script>
   
@@ -598,11 +595,11 @@
       console.log('  - utils/dates.js');
       console.log('  - utils/badges.js');
       console.log('  - utils/dom.js');
-      console.log('  - kanban-app.js');
+      console.log('  - core/KanbanManager.js');
       console.log('');
       console.log('🔧 Debug disponible:');
       console.log('  - window.kanbanManager : Instance principale');
-      console.log('  - window.KanbanApp : Utilitaires exposés');
+      console.log('  - window.kanbanAppInitializer : Initialiseur courant');
       console.log('  - logger.setLogLevel(\"INFO\") : Activer logs détaillés');
       console.log('');
       console.log('⌨️  Raccourcis:');

--- a/test/js/app-initializer.js
+++ b/test/js/app-initializer.js
@@ -743,7 +743,8 @@ export class KanbanAppInitializer {
       if (kanban && kanban.currentRecords && kanban.currentRecords.length <= 2) {
         
         // Essayer de recharger les données depuis Grist
-        if (kanban.gristManager?.isConnected && typeof grist !== 'undefined') {
+        const gristAvailable = typeof window !== 'undefined' && typeof window.grist !== 'undefined';
+        if (kanban.gristManager?.isConnected && gristAvailable) {
           console.log('🔄 Tentative de rechargement automatique...');
           kanban.gristManager.reloadData()
             .then(() => {
@@ -779,7 +780,9 @@ let appInitializer = null;
 document.addEventListener('DOMContentLoaded', async () => {
   try {
     appInitializer = new KanbanAppInitializer();
-    
+
+    window.kanbanAppInitializer = appInitializer;
+
     await appInitializer.init();
   } catch (error) {
     console.error('❌ Échec de l\'initialisation de l\'application:', error);
@@ -789,4 +792,3 @@ document.addEventListener('DOMContentLoaded', async () => {
 
 // Exposition globale
 window.KanbanAppInitializer = KanbanAppInitializer;
-window.kanbanAppInitializer = appInitializer;

--- a/test/js/config/strategyFallbackData.js
+++ b/test/js/config/strategyFallbackData.js
@@ -1,0 +1,392 @@
+// === config/strategyFallbackData.js ===
+// Données stratégiques intégrées utilisées comme repli hors Grist
+
+export const STRATEGY_DATA = [
+  {
+    "id": 1,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Appliquer les dispositions organisationnelles des annexes 1 et 2",
+    "action": "Refonte et simplification des nomenclatures de groupes de sécurité et des groupes de distribution, et création de groupes, comptes, boîte mail ou liste de diffusion par le bureau exploitation.",
+    "responsable": "Exploitation",
+    "echeance": "2024-2025",
+    "portee": "GSSI"
+  },
+  {
+    "id": 2,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Appliquer les dispositions organisationnelles des annexes 1 et 2",
+    "action": "Établissement de procédures partagées (bonnes pratiques)",
+    "responsable": "Exploitation",
+    "echeance": "2024-2025",
+    "portee": "GSSI"
+  },
+  {
+    "id": 3,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Appliquer les dispositions organisationnelles des annexes 1 et 2",
+    "action": "Création et animation du réseau des correspondants informatiques",
+    "responsable": "CGSSI+ISI",
+    "echeance": "2024-2025",
+    "portee": "GSSI"
+  },
+  {
+    "id": 4,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Appliquer les dispositions organisationnelles des annexes 1 et 2",
+    "action": "Ouverture d'un guichet unique",
+    "responsable": "GSSI",
+    "echeance": "2024-2025",
+    "portee": "GSSI"
+  },
+  {
+    "id": 5,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Appliquer les dispositions organisationnelles des annexes 1 et 2",
+    "action": "Attribution des privilèges d'accès selon des critères respectant le principe du moindre privilège.",
+    "responsable": "Exploitation",
+    "echeance": "2024-2025",
+    "portee": "GSSI"
+  },
+  {
+    "id": 6,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Mise en conformité et durcissement de l'AD",
+    "responsable": "Exploitation",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 7,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Suivi du plan d'action de l'audit réseau pour disposer d'une architecture réseau simplifiée, segmentée, exploitable et maintenable",
+    "responsable": "Réseaux",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 8,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Mise en place d'un outil de suivi et anticipation des actions",
+    "responsable": "Réseaux",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 9,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Simplification des architectures : internet, intranet, extranet, serveurs de fichiers, serveur mail…",
+    "responsable": "Réseaux",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 10,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Sécurisation et homogénéisation des moyens d'accès distant (RDS, VPN, dotations en matériel portable)",
+    "responsable": "ISI+CGSSI",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 11,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Sécurisation et homogénéisation des moyens d'accès distant (RDS, VPN, dotations en matériel portable)",
+    "responsable": "Exploitation",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 12,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre en conformité les réseaux, logiciels et matériels",
+    "action": "Sécurisation et homogénéisation des moyens d'accès distant (RDS, VPN, dotations en matériel portable)",
+    "responsable": "ISI+RSSI",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 13,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique du SDIS",
+    "action": "Rédaction d'une charte utilisateur des systèmes d'information",
+    "responsable": "GSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 14,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique du SDIS",
+    "action": "Rédaction d'une charte spécifique pour les administrateurs système et les correspondants",
+    "responsable": "GSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 15,
+    "objectif": "Assurer le fonctionnement des systèmes d'information",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique du SDIS",
+    "action": "Élaboration d'un plan de sauvegarde des données",
+    "responsable": "GSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 16,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Établir la PSSI",
+    "action": "Réalisation d'un audit sécurité : conformité à NIS2",
+    "responsable": "ISI+RSSI+CGSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 17,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Établir la PSSI",
+    "action": "Rédaction d'une PSSI prenant en compte la réglementation NIS2 et sa transposition.",
+    "responsable": "ISI+RSSI+CGSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 18,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Appliquer la PSSI",
+    "action": "Mise en place de procédures et actions prenant en compte la PSSI",
+    "responsable": "GSSI+SDIS",
+    "echeance": "2025-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 19,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Surveiller les activités informatiques",
+    "action": "Amélioration des outils de supervision",
+    "responsable": "RSSI+ISI",
+    "echeance": "2024-2026",
+    "portee": "Générale"
+  },
+  {
+    "id": 20,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Surveiller les activités informatiques",
+    "action": "Mise en conformité de la logique d'exposition sur internet",
+    "responsable": "RSSI+ISI",
+    "echeance": "2024-2026",
+    "portee": "Générale"
+  },
+  {
+    "id": 21,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Indicateurs de sécurité",
+    "action": "Mise en place et partage d'indicateurs de sécurité",
+    "responsable": "RSSI + CGSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 22,
+    "objectif": "Garantir la sécurité des systèmes d'information",
+    "sous_objectif": "Indicateurs de sécurité",
+    "action": "Sensibilisation/formation à partir de ces indicateurs.",
+    "responsable": "RSSI + CGSSI",
+    "echeance": "2025",
+    "portee": "Générale"
+  },
+  {
+    "id": 23,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Pérenniser les outils à destination des métiers et utilisateurs",
+    "action": "Transmission des connaissances d'exploitation et développement d'intranet",
+    "responsable": "ISI",
+    "echeance": "2024-",
+    "portee": "Générale"
+  },
+  {
+    "id": 24,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Pérenniser les outils à destination des métiers et utilisateurs",
+    "action": "Aide à la maitrise d'ouvrage pour la continuité des outils et le support avec les fournisseurs de logiciels",
+    "responsable": "ISI",
+    "echeance": "2024-",
+    "portee": "Générale"
+  },
+  {
+    "id": 25,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Pérenniser les outils à destination des métiers et utilisateurs",
+    "action": "Mise en œuvre d'un outil de déploiement automatisé",
+    "responsable": "ISI",
+    "echeance": "2024-",
+    "portee": "Générale"
+  },
+  {
+    "id": 26,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Préciser les démarches de qualification et validation du GSSI (AMO)",
+    "action": "Document cadre (schéma directeur)",
+    "responsable": "ISI+CGSSI",
+    "echeance": "2024",
+    "portee": "Générale"
+  },
+  {
+    "id": 27,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Préciser les démarches de qualification et validation du GSSI (AMO)",
+    "action": "Réunions avec chefs de groupements",
+    "responsable": "CGSSI",
+    "echeance": "2024-",
+    "portee": "Générale"
+  },
+  {
+    "id": 28,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Organiser les modalités de saisines et le suivi des réponses du service aux sollicitations",
+    "action": "Simplification et optimisation du traitement des demandes avec guichet unique (pour l'instant GLPI et intranet)",
+    "responsable": "RSSI+exploitation",
+    "echeance": "2024-",
+    "portee": "Générale"
+  },
+  {
+    "id": 29,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Organiser les modalités de saisines et le suivi des réponses du service aux sollicitations",
+    "action": "Mise en place d'un inventaire automatisé en lien avec un outil de déploiement des matériels",
+    "responsable": "RSSI+exploitation",
+    "echeance": "2024-",
+    "portee": "Générale"
+  },
+  {
+    "id": 30,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Organiser les modalités de saisines et le suivi des réponses du service aux sollicitations",
+    "action": "Mise en place d'un inventaire automatisé en lien avec un outil de déploiement des matériels",
+    "responsable": "Exploitation",
+    "echeance": "2024",
+    "portee": "Générale"
+  },
+  {
+    "id": 31,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Mettre en place les solutions NexSIS-RRF",
+    "action": "Évaluer le retroplanning avec les grandes actions",
+    "responsable": "Équipe projet",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 32,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Mettre en place les solutions NexSIS-RRF",
+    "action": "Définir les budgets et échéances financières",
+    "responsable": "Équipe projet",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 33,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Mettre en place les solutions NexSIS-RRF",
+    "action": "Prévoir et accompagner les évolutions techniques",
+    "responsable": "Équipe projet",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 34,
+    "objectif": "Répondre aux demandes des métiers",
+    "sous_objectif": "Mettre en place les solutions NexSIS-RRF",
+    "action": "Former et tenir au fait les utilisateurs",
+    "responsable": "Équipe projet",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 35,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Bâtir les systèmes d'information de demain",
+    "action": "Évaluer l'existant : intranet, extranet, GED, GEC, SAE, logiciels, intégration",
+    "responsable": "Groupe de travail",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 36,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Bâtir les systèmes d'information de demain",
+    "action": "Benchmark dans les autres SIS",
+    "responsable": "Groupe de travail",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 37,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Bâtir les systèmes d'information de demain",
+    "action": "Proposer les outils de demain (informatique = cloud, outils de communication modernes, téléphonie)",
+    "responsable": "Groupe de travail",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 38,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Bâtir les systèmes d'information de demain",
+    "action": "Mettre en place les outils de demain (nouvel intranet, workflows, tableaux de bord, outils de pilotage, circulation de l'information…)",
+    "responsable": "Groupe de travail",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 39,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Bâtir les systèmes d'information de demain",
+    "action": "Prendre en compte le PCA (Cloud, infrastructures réseau, communication, etc.)",
+    "responsable": "Groupe de travail",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 40,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique",
+    "action": "Prendre en compte les évolutions validées suite aux travaux des groupes",
+    "responsable": "GSSI",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 41,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique",
+    "action": "Produire les plans de continuité et/ou de reprise de l'activité",
+    "responsable": "GSSI",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 42,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique",
+    "action": "Veiller à la cohérence du système, aux opérations de nettoyage et de documentation",
+    "responsable": "GSSI",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  },
+  {
+    "id": 43,
+    "objectif": "Assurer la transition vers les systèmes d'information de demain",
+    "sous_objectif": "Mettre à jour le schéma directeur informatique",
+    "action": "Inclure les nouveaux outils, les solutions émergentes",
+    "responsable": "GSSI",
+    "echeance": "2024-2030",
+    "portee": "Générale"
+  }
+];

--- a/test/js/core/KanbanManager.js
+++ b/test/js/core/KanbanManager.js
@@ -18,6 +18,7 @@ import { BoardRenderer } from '../renderers/boardRenderer.js';
 
 // Importation du gestionnaire Grist
 import { GristManager } from '../managers/GristManager.js';
+import { STRATEGY_DATA as FALLBACK_STRATEGY_DATA } from '../config/strategyFallbackData.js';
 
 /**
  * Orchestrateur principal de l'application Kanban (version all�g�e)
@@ -104,7 +105,7 @@ export class KanbanManager {
     }
     
     // V�rifier la pr�sence de Grist
-    if (typeof grist === 'undefined') {
+    if (typeof window === 'undefined' || typeof window.grist === 'undefined') {
       throw new Error('API Grist non disponible');
     }
     
@@ -179,15 +180,66 @@ export class KanbanManager {
    * Charge les données stratégiques depuis Grist
    */
   async loadStrategyData() {
-    // Stratégies chargées uniquement si nécessaire (pas en temps réel)
     try {
       const strategyRecords = await this.gristManager.fetchTable('Ssir_strategie2');
-      this.strategyData = this.mapStrategyRecords(strategyRecords);
-      this.strategiesData = this.strategyData; // Alias pour ModalManager
+      const mappedStrategies = this.mapStrategyRecords(strategyRecords);
+
+      if (mappedStrategies.length > 0) {
+        this.strategyData = mappedStrategies;
+        this.strategiesData = mappedStrategies; // Alias pour ModalManager
+        return;
+      }
+
+      console.warn('KanbanManager: Aucune stratégie reçue depuis Grist - activation du repli statique');
+      this.applyStrategyFallbackData('aucune donnée Grist');
     } catch (error) {
-      // Fonctionnement dégradé sans stratégies
+      console.warn('KanbanManager: Erreur lors du chargement des stratégies depuis Grist:', error);
+      this.applyStrategyFallbackData(error?.message || 'erreur Grist');
+    }
+  }
+
+  /**
+   * Applique les données stratégiques intégrées en cas d'indisponibilité Grist
+   * @param {string} [reason] - Raison affichée dans les logs
+   */
+  applyStrategyFallbackData(reason = '') {
+    if (!Array.isArray(FALLBACK_STRATEGY_DATA) || FALLBACK_STRATEGY_DATA.length === 0) {
+      console.warn('KanbanManager: Aucune donnée stratégique de repli disponible');
       this.strategyData = [];
       this.strategiesData = [];
+      return;
+    }
+
+    const suffix = reason ? ` (${reason})` : '';
+    console.warn(`KanbanManager: Utilisation des données stratégiques intégrées${suffix}`);
+
+    this.strategyData = FALLBACK_STRATEGY_DATA
+      .map((entry) => {
+        const sourceId = entry.id ?? entry.id2 ?? null;
+        const parsedId = parseInt(sourceId, 10);
+        const normalizedId = Number.isNaN(parsedId) ? sourceId : parsedId;
+
+        return {
+          id: normalizedId,
+          objectif: entry.objectif || '',
+          sous_objectif: entry.sous_objectif || '',
+          action: entry.action || '',
+          echeance: entry.echeance || '',
+          responsable: entry.responsable || '',
+          portee: entry.portee || ''
+        };
+      })
+      .filter((strategy) =>
+        strategy.id !== null && typeof strategy.id !== 'undefined' &&
+        strategy.objectif && strategy.sous_objectif && strategy.action
+      );
+
+    this.strategiesData = this.strategyData;
+
+    if (this.strategyData.length > 0) {
+      console.log(`KanbanManager: ${this.strategyData.length} stratégies chargées depuis le repli statique`);
+    } else {
+      console.warn('KanbanManager: Données de repli présentes mais aucun enregistrement exploitable');
     }
   }
   
@@ -222,33 +274,48 @@ export class KanbanManager {
    * @returns {Array} Enregistrements mappés
    */
   mapStrategyRecords(records) {
+    if (!records || typeof records !== 'object') {
+      return [];
+    }
+
+    const idColumn = Array.isArray(records.id)
+      ? records.id
+      : Array.isArray(records.id_task)
+        ? records.id_task
+        : null;
+
+    if (!idColumn) {
+      console.warn('KanbanManager: Structure des stratégies inattendue - colonne id absente');
+      return [];
+    }
+
     const mapped = [];
-    
-    // Les clés sont les IDs des enregistrements
-    const ids = Object.keys(records.id || {});
-    
-    ids.forEach(id => {
+    const total = idColumn.length;
+
+    for (let index = 0; index < total; index++) {
       try {
+        const rawId = idColumn[index];
+        const parsedId = parseInt(rawId, 10);
+        const normalizedId = Number.isNaN(parsedId) ? rawId : parsedId;
+
         const strategy = {
-          id: records.id[id],
-          objectif: records.objectif?.[id] || '',
-          sous_objectif: records.sous_objectif?.[id] || '',
-          action: records.action?.[id] || '',
-          echeance: records.echeance?.[id] || '',
-          responsable: records.responsable?.[id] || '',
-          portee: records.portee?.[id] || ''
+          id: normalizedId,
+          objectif: Array.isArray(records.objectif) ? records.objectif[index] || '' : '',
+          sous_objectif: Array.isArray(records.sous_objectif) ? records.sous_objectif[index] || '' : '',
+          action: Array.isArray(records.action) ? records.action[index] || '' : '',
+          echeance: Array.isArray(records.echeance) ? records.echeance[index] || '' : '',
+          responsable: Array.isArray(records.responsable) ? records.responsable[index] || '' : '',
+          portee: Array.isArray(records.portee) ? records.portee[index] || '' : ''
         };
-        
-        // Ne garder que les stratégies complètes
+
         if (strategy.objectif && strategy.sous_objectif && strategy.action) {
           mapped.push(strategy);
         }
-        
       } catch (error) {
-        console.warn('KanbanManager: Erreur mapping stratégie:', id, error);
+        console.warn('KanbanManager: Erreur mapping stratégie:', index, error);
       }
-    });
-    
+    }
+
     return mapped;
   }
   

--- a/test/js/managers/GristManager.js
+++ b/test/js/managers/GristManager.js
@@ -44,21 +44,22 @@ export class GristManager {
   waitForGristReady() {
     return new Promise((resolve, reject) => {
       try {
-        // Éviter les appels multiples à grist.ready()
+        const gristApi = this.getGristApi();
+        // Éviter les appels multiples à window.grist.ready()
         if (!window._gristReadyInitialized) {
-          grist.ready({ 
+          gristApi.ready({
             requiredAccess: 'full',
             onEditOptions: () => this.handleEditOptions()
           });
-          
-          grist.onRecords((records, mappings) => {
+
+          gristApi.onRecords((records, mappings) => {
             this.handleRecordsUpdate(records, mappings);
           });
-          
-          grist.onOptions((options) => {
+
+          gristApi.onOptions((options) => {
             this.handleOptionsUpdate(options);
           });
-          
+
           window._gristReadyInitialized = true;
         }
         
@@ -75,9 +76,10 @@ export class GristManager {
   async loadInitialData() {
     try {
       this.logger.debug('Chargement des données...');
-      
+
       // Charger les enregistrements de la table principale
-      const records = await grist.docApi.fetchTable(TABLE_ID);
+      const gristApi = this.getGristApi();
+      const records = await gristApi.docApi.fetchTable(TABLE_ID);
       
       if (records && typeof records === 'object') {
         // Détecter les colonnes disponibles
@@ -275,25 +277,26 @@ export class GristManager {
     if (this.isUpdating) {
       throw new Error('Une sauvegarde est déjà en cours');
     }
-    
+
     this.isUpdating = true;
-    
+
     try {
       // Valider les données
       this.validateRecordData(recordData);
-      
+
       // Préparer les données pour Grist
       const gristData = this.prepareDataForGrist(recordData);
-      
+      const gristApi = this.getGristApi();
+
       let result;
-      
+
       if (recordId) {
         // Mise à jour
         this.logger.debug(`Mise à jour enregistrement ${recordId}`);
-        await grist.docApi.applyUserActions([
+        await gristApi.docApi.applyUserActions([
           ['UpdateRecord', TABLE_ID, recordId, gristData]
         ]);
-        
+
         // Mettre à jour localement
         this.updateLocalRecord(recordId, gristData);
         result = { id: recordId, ...gristData };
@@ -301,7 +304,7 @@ export class GristManager {
       } else {
         // Création
         this.logger.debug('Création nouvel enregistrement');
-        const actionResult = await grist.docApi.applyUserActions([
+        const actionResult = await gristApi.docApi.applyUserActions([
           ['AddRecord', TABLE_ID, null, gristData]
         ]);
         
@@ -337,13 +340,14 @@ export class GristManager {
     if (this.isUpdating) {
       throw new Error('Une opération est déjà en cours');
     }
-    
+
     this.isUpdating = true;
-    
+
     try {
       this.logger.debug(`Suppression enregistrement ${recordId}`);
-      
-      await grist.docApi.applyUserActions([
+      const gristApi = this.getGristApi();
+
+      await gristApi.docApi.applyUserActions([
         ['RemoveRecord', TABLE_ID, recordId]
       ]);
       
@@ -548,8 +552,9 @@ export class GristManager {
    */
   async reloadData() {
     try {
-      const records = await grist.docApi.fetchTable(TABLE_ID);
-      
+      const gristApi = this.getGristApi();
+      const records = await gristApi.docApi.fetchTable(TABLE_ID);
+
       if (records) {
         this.currentRecords = this.mapGristRecords(records);
         await this.loadGristOptions();
@@ -567,7 +572,14 @@ export class GristManager {
       throw error;
     }
   }
-  
+
+  getGristApi() {
+    if (typeof window === 'undefined' || typeof window.grist === 'undefined') {
+      throw new Error('API Grist non disponible');
+    }
+    return window.grist;
+  }
+
   /**
    * Recherche d'enregistrements avec critères
    * @param {object} criteria - Critères de recherche
@@ -707,7 +719,7 @@ export class GristManager {
    * @returns {boolean} True si connecté
    */
   isGristConnected() {
-    return this.isConnected && typeof grist !== 'undefined';
+    return this.isConnected && typeof window.grist !== 'undefined';
   }
   
   /**
@@ -716,7 +728,8 @@ export class GristManager {
    */
   async getUserInfo() {
     try {
-      const docInfo = await grist.docApi.getDocInfo();
+      const gristApi = this.getGristApi();
+      const docInfo = await gristApi.docApi.getDocInfo();
       return {
         user: docInfo.user || null,
         permissions: docInfo.permissions || {},
@@ -751,7 +764,8 @@ export class GristManager {
   async fetchTable(tableId) {
     try {
       this.logger.debug(`Chargement table ${tableId}...`);
-      const records = await grist.docApi.fetchTable(tableId);
+      const gristApi = this.getGristApi();
+      const records = await gristApi.docApi.fetchTable(tableId);
       this.logger.debug(`Table ${tableId} chargée: ${Object.keys(records.id || {}).length} enregistrements`);
       return records;
     } catch (error) {

--- a/test/js/managers/HistoryManager.js
+++ b/test/js/managers/HistoryManager.js
@@ -144,7 +144,8 @@ export class HistoryManager {
     try {
       targetElement.innerHTML = '<div class="text-center py-2"><div class="spinner-border spinner-border-sm"></div></div>';
       
-      const gristData = await grist.docApi.fetchTable(TABLE_ID);
+      const gristApi = this.getGristApi();
+      const gristData = await gristApi.docApi.fetchTable(TABLE_ID);
       const mappedRecords = this.kanban.mapGristRecords(gristData);
       const task = mappedRecords.find(r => r.id === taskId);
       
@@ -1956,7 +1957,8 @@ export class HistoryManager {
   async updateCommentInGrist(taskId, commentId, newContent) {
     try {
       // Récupérer la tâche actuelle depuis Grist
-      const gristData = await grist.docApi.fetchTable(TABLE_ID);
+      const gristApi = this.getGristApi();
+      const gristData = await gristApi.docApi.fetchTable(TABLE_ID);
       
       // Trouver l'enregistrement
       const index = gristData.id.findIndex(id => id === taskId);
@@ -2076,8 +2078,8 @@ export class HistoryManager {
       const updatedNotes = JSON.stringify(notesData);
       this.logger.debug('Sauvegarde des notes mises à jour:', updatedNotes.length > 100 ? 'Notes très longues...' : updatedNotes);
       
-      await grist.docApi.applyUserActions([
-        ['UpdateRecord', TABLE_ID, taskId, { 
+      await gristApi.docApi.applyUserActions([
+        ['UpdateRecord', TABLE_ID, taskId, {
           notes: updatedNotes,
           date_derniere_maj: new Date().toISOString()
         }]
@@ -2091,6 +2093,22 @@ export class HistoryManager {
     }
   }
   
+  /**
+   * Récupère l'API Grist disponible
+   * @returns {object}
+   */
+  getGristApi() {
+    if (this.kanban?.gristManager?.getGristApi) {
+      return this.kanban.gristManager.getGristApi();
+    }
+
+    if (typeof window !== 'undefined' && typeof window.grist !== 'undefined') {
+      return window.grist;
+    }
+
+    throw new Error('API Grist non disponible');
+  }
+
   /**
    * Récupère l'utilisateur actuel
    * @returns {Promise<string>}


### PR DESCRIPTION
## Summary
- add the production strategy dataset to the test environment so strategic features stay available when Grist data is missing
- teach KanbanManager to prefer live Grist strategies but fall back to the static dataset with additional mapping guards

## Testing
- not run (no automated test suite provided)


------
https://chatgpt.com/codex/tasks/task_e_68f93a3bb86483319c33e774d50b8a98