### PR TITLE
Revert test kanban regressions and wait for Grist

### DIFF
--- a/test/js/app-initializer.js
+++ b/test/js/app-initializer.js
@@ -165,22 +165,31 @@ export class KanbanAppInitializer {
    */
   async loadApplicationData() {
     const kanban = this.components.kanbanManager;
-    
+
+    // Attendre explicitement la connexion Grist pour éviter les faux positifs
+    if (kanban.gristManager) {
+      if (!kanban.gristManager.isConnected) {
+        await this.waitForComponent(
+          () => kanban.gristManager?.isConnected,
+          15000,
+          'GristManager.isConnected'
+        );
+      }
+    } else {
+      throw new Error('GristManager non initialisé');
+    }
+
     if (!kanban.currentRecords || kanban.currentRecords.length === 0) {
-      if (kanban.gristManager?.isConnected) {
-        try {
-          await kanban.gristManager.reloadData();
-        } catch (error) {
-          throw new Error('Impossible de charger les données depuis Grist: ' + error.message);
-        }
-      } else {
-        throw new Error('Grist non connecté - impossible de charger les données');
+      try {
+        await kanban.gristManager.reloadData();
+      } catch (error) {
+        throw new Error('Impossible de charger les données depuis Grist: ' + error.message);
       }
     }
-    
+
     // Valider la cohérence des données
     this.validateDataIntegrity();
-    
+
   }
   
   /**


### PR DESCRIPTION
## Summary
- restore the test kanban HTML, CSS, and managers to the production-aligned baseline so the layout, filters, and modals behave normally
- drop the test-only strategy fallback dataset so strategy and select options come from live Grist data
- wait for the Grist connection before loading records to stop the transient initialization error

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68f93a3bb86483319c33e774d50b8a98