### PR TITLE
Restore modular test view stack and fix strategy mapping

### DIFF
--- a/test/js/core/KanbanManager.js
+++ b/test/js/core/KanbanManager.js
@@ -266,12 +266,11 @@ export class KanbanManager {
 
     ids.forEach((id, index) => {
       try {
-        const rawId = idColumn[index];
-        const parsedId = parseInt(rawId, 10);
-        const normalizedId = Number.isNaN(parsedId) ? rawId : parsedId;
+        const parsedId = typeof id === 'number' ? id : parseInt(id, 10);
+        const normalizedId = Number.isNaN(parsedId) ? id : parsedId;
 
         const strategy = {
-          id,
+          id: normalizedId,
           objectif: objectifs[index] || '',
           sous_objectif: sousObjectifs[index] || '',
           action: actions[index] || '',


### PR DESCRIPTION
## Summary
- revert the test bundle to the modular ViewModeManager + renderer architecture used in production
- restore CardRenderer and BoardRenderer modules and rewire the managers to the original APIs
- fix the strategy record mapper to return valid IDs without referencing an undefined variable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb94829b6c8331bf2f41be3661a281