### PR TITLE
Fix Grist mapping and strategy fallback in test bundle

### DIFF
--- a/test/js/config/constants.js
+++ b/test/js/config/constants.js
@@ -44,9 +44,8 @@ export const TABLE_ID = "Ssir_principale_task";
 
 // === COLONNES REQUISES ET OPTIONNELLES ===
 export const REQUIRED_COLUMNS = [
-  'id_task', 'titre', 'description', 'statut', 'bureau', 'qui', 'urgence', 'impact',
+  'id', 'id_task', 'titre', 'description', 'statut', 'bureau', 'qui', 'urgence', 'impact',
   'projet', 'strategie_id', 'notes', 'date_derniere_maj', 'statut_precedent'
-  // Note: id_task est l'identifiant unique (pas 'id')
   // Note: reference et jalons sont maintenant dans OPTIONAL_COLUMNS (comme en prod)
 ];
 

--- a/test/js/core/KanbanManager.js
+++ b/test/js/core/KanbanManager.js
@@ -204,6 +204,25 @@ export class KanbanManager {
       if (this.modalManager) {
         this.modalManager.handleStrategyDataLoaded([]);
       }
+      return;
+    }
+
+    console.warn(`KanbanManager: utilisation des données stratégiques de secours (${reason})`);
+    const fallbackStrategies = FALLBACK_STRATEGY_DATA.map(strategy => ({
+      id: strategy.id,
+      objectif: strategy.objectif || '',
+      sous_objectif: strategy.sous_objectif || '',
+      action: strategy.action || '',
+      echeance: strategy.echeance || '',
+      responsable: strategy.responsable || '',
+      portee: strategy.portee || ''
+    }));
+
+    this.strategyData = fallbackStrategies;
+    this.strategiesData = fallbackStrategies;
+
+    if (this.modalManager) {
+      this.modalManager.handleStrategyDataLoaded(fallbackStrategies);
     }
   }
   
@@ -266,12 +285,11 @@ export class KanbanManager {
 
     ids.forEach((id, index) => {
       try {
-        const rawId = idColumn[index];
-        const parsedId = parseInt(rawId, 10);
-        const normalizedId = Number.isNaN(parsedId) ? rawId : parsedId;
+        const parsedId = typeof id === 'number' ? id : parseInt(id, 10);
+        const normalizedId = Number.isNaN(parsedId) ? id : parsedId;
 
         const strategy = {
-          id,
+          id: normalizedId,
           objectif: objectifs[index] || '',
           sous_objectif: sousObjectifs[index] || '',
           action: actions[index] || '',

--- a/test/js/managers/GristManager.js
+++ b/test/js/managers/GristManager.js
@@ -146,13 +146,13 @@ export class GristManager {
     }
     
     const keys = Object.keys(gristData);
-    if (!keys.includes('id_task') || !Array.isArray(gristData.id_task)) {
-      this.logger.warn('Structure de données Grist invalide - colonne id_task manquante');
+    if (!keys.includes('id') || !Array.isArray(gristData.id)) {
+      this.logger.warn('Structure de données Grist invalide - colonne id manquante');
       this.logger.debug('Colonnes disponibles:', keys.slice(0, 10));
       return [];
     }
-    
-    const recordCount = gristData.id_task.length;
+
+    const recordCount = gristData.id.length;
     
     for (let i = 0; i < recordCount; i++) {
       const record = {};
@@ -160,12 +160,12 @@ export class GristManager {
       
       // Mapper les colonnes requises
       for (const columnName of REQUIRED_COLUMNS) {
-        if (gristData.hasOwnProperty(columnName) && 
-            Array.isArray(gristData[columnName]) && 
+        if (gristData.hasOwnProperty(columnName) &&
+            Array.isArray(gristData[columnName]) &&
             gristData[columnName].length > i) {
-          
+
           const value = gristData[columnName][i];
-          
+
           // Traitement spécial pour les listes (bureau, qui)
           if ((columnName === 'bureau' || columnName === 'qui')) {
             if (Array.isArray(value) && value[0] === 'L') {
@@ -176,9 +176,9 @@ export class GristManager {
           } else {
             record[columnName] = value;
           }
-          
-        } else if (columnName === 'id_task') {
-          // L'id_task est absolument requis
+
+        } else if (columnName === 'id') {
+          // L'identifiant de ligne est absolument requis
           isValidRecord = false;
           break;
         } else {
@@ -207,12 +207,21 @@ export class GristManager {
       
       // Valider et ajouter l'enregistrement
       if (isValidRecord) {
-        // Utiliser id_task comme identifiant unique et créer un id pour compatibilité
-        record.id = parseInt(record.id_task, 10);
-        if (!isNaN(record.id) && record.id > 0) {
+        const parsedId = parseInt(record.id, 10);
+        if (!Number.isNaN(parsedId) && parsedId > 0) {
+          record.id = parsedId;
+
+          // Assurer un id_task numérique cohérent si disponible
+          if (record.id_task === null || record.id_task === undefined) {
+            record.id_task = parsedId;
+          } else if (typeof record.id_task === 'string') {
+            const parsedTaskId = parseInt(record.id_task, 10);
+            record.id_task = Number.isNaN(parsedTaskId) ? record.id_task : parsedTaskId;
+          }
+
           records.push(record);
         } else {
-          this.logger.warn(`Record invalide - id_task: ${record.id_task}`);
+          this.logger.warn(`Record invalide - id: ${record.id}`);
         }
       }
     }


### PR DESCRIPTION
## Summary
- require the Grist row identifier in the test bundle so we keep the real record id alongside id_task
- update the test Grist mapper to derive numeric ids safely and preserve id_task for compatibility
- restore the strategy fallback loader so the modal still has options if Grist queries fail

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb94829b6c8331bf2f41be3661a281