### PR TITLE
Prevent project badges from overflowing in detailed view

### DIFF
--- a/kanbantest/css/kanban-base.css
+++ b/kanbantest/css/kanban-base.css
@@ -597,8 +597,14 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex: 0 1 auto;
+  max-width: 100%;
+  min-width: 0;
   padding: 0.375rem 0.5rem;
-  line-height: 1;
+  line-height: 1.1;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .item-badges .badge.bg-info:hover {

--- a/kanbantest/css/kanban-responsive.css
+++ b/kanbantest/css/kanban-responsive.css
@@ -224,20 +224,21 @@
   .kanban-container {
     gap: 1.5rem;
   }
-  
+
   .kanban-container > .kanban-board {
-    flex: 0 0 320px;
-    min-width: 320px;
+    flex: 0 0 340px;
+    min-width: 340px;
   }
-  
+
   .kanban-container.kanban-compact > .kanban-board {
     flex: 0 0 250px;
     min-width: 250px;
   }
-  
+
   .kanban-container.kanban-detailed > .kanban-board {
-    flex: 0 0 280px;
-    min-width: 280px;
+    flex: 0 0 360px;
+    min-width: 360px;
+    max-width: 360px;
   }
 }
 
@@ -249,8 +250,14 @@
   }
   
   .kanban-container > .kanban-board {
-    flex: 0 0 280px;
-    min-width: 280px;
+    flex: 0 0 320px;
+    min-width: 320px;
+  }
+
+  .kanban-container.kanban-detailed > .kanban-board {
+    flex: 0 0 340px;
+    min-width: 340px;
+    max-width: 340px;
   }
   
   .kanban-container.kanban-compact {
@@ -288,19 +295,26 @@
 }
 
 /* Small screens (phones) */
-  @media (max-width: 767.98px) {
-    .kanban-container {
-      gap: 0.75rem;
-      padding: 0 0.25rem;
-    }
+@media (max-width: 767.98px) {
+  .kanban-container {
+    gap: 0.75rem;
+    padding: 0 0.25rem;
+  }
 
-    .kanban-container > .kanban-board {
-      flex: 0 0 280px;
-      min-width: 280px;
-    }
-    .kanban-board {
-      min-height: auto;
-    }
+  .kanban-container > .kanban-board {
+    flex: 0 0 320px;
+    min-width: 320px;
+  }
+
+  .kanban-container.kanban-detailed > .kanban-board {
+    flex: 0 0 340px;
+    min-width: 340px;
+    max-width: 340px;
+  }
+
+  .kanban-board {
+    min-height: auto;
+  }
 
     .kanban-board-body {
       padding: 0.5rem;


### PR DESCRIPTION
## Summary
- allow project badges to wrap and shrink so long project names no longer overflow cards
- keep wider detailed columns across breakpoints so the horizontal navigation arrows manage overflow instead of shrinking badges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690252c2d60883319438c92357c44967