### PR TITLE
Réactiver le JalonManager dans la version prod

### DIFF
--- a/kanban/js/core/KanbanManager.js
+++ b/kanban/js/core/KanbanManager.js
@@ -11,6 +11,7 @@ import { ModalManager } from '../managers/ModalManager.js';
 import { HistoryManager } from '../managers/HistoryManager.js';
 import { FilterManager } from '../managers/FilterManager.js';
 import { ViewManager } from '../managers/ViewManager.js';
+import { JalonManager } from '../managers/JalonManager.js';
 
 // Importation du gestionnaire Grist
 import { GristManager } from '../managers/GristManager.js';
@@ -34,6 +35,7 @@ export class KanbanManager {
     this.historyManager = null;
     this.filterManager = null;
     this.viewManager = null;
+    this.jalonManager = null;
     
     // �tat des donn�es
     this.currentRecords = [];
@@ -137,7 +139,10 @@ export class KanbanManager {
     // 5. Gestionnaire de filtres
     this.filterManager = new FilterManager(this);
 
-    // 6. Gestionnaire de vues et de rendu
+    // 6. Gestionnaire des jalons (doit être initialisé après ModalManager)
+    this.jalonManager = new JalonManager(this);
+
+    // 7. Gestionnaire de vues et de rendu
     this.viewManager = new ViewManager(this);
 
     console.log('KanbanManager: Gestionnaires initialisés');

--- a/test/css/kanban-modal.css
+++ b/test/css/kanban-modal.css
@@ -98,6 +98,45 @@
   gap: 1.1rem;
 }
 
+.task-meta-grid.taxonomy-grid .task-meta-item {
+  min-height: 100%;
+}
+
+.task-meta-grid.taxonomy-grid .form-text {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.task-meta-item.dette-technique-item {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.task-meta-item.dette-technique-item .form-check {
+  padding-left: 2.5rem;
+}
+
+.task-meta-item.dette-technique-item .form-check-input {
+  width: 3rem;
+  height: 1.5rem;
+}
+
+.task-meta-item.dette-technique-item .form-check-label {
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .task-meta-item.dette-technique-item {
+    align-items: flex-start;
+  }
+
+  .task-meta-item.dette-technique-item .form-check {
+    padding-left: 2rem;
+  }
+}
+
 .task-meta-item .input-group > .form-select,
 .task-meta-item .input-group > .form-control {
   font-size: 0.95rem;

--- a/test/index.html
+++ b/test/index.html
@@ -196,6 +196,32 @@
                     </div>
                   </div>
                 </div>
+                <div class="task-meta-grid mt-3 taxonomy-grid">
+                  <div class="task-meta-item">
+                    <label for="popup-previsibilite" class="form-label">Prévisibilité</label>
+                    <select class="form-select" id="popup-previsibilite">
+                      <option value="">-- Prévisibilité --</option>
+                    </select>
+                  </div>
+                  <div class="task-meta-item">
+                    <label for="popup-type-tache" class="form-label">Type de tâche</label>
+                    <select class="form-select" id="popup-type-tache">
+                      <option value="">-- Type de tâche --</option>
+                    </select>
+                  </div>
+                  <div class="task-meta-item">
+                    <label for="popup-temps-estime" class="form-label">Temps estimé (h)</label>
+                    <input type="number" class="form-control" id="popup-temps-estime" min="0" step="0.25" placeholder="ex : 2.5">
+                    <div class="form-text">Saisir un nombre d'heures (décimales autorisées).</div>
+                  </div>
+                  <div class="task-meta-item dette-technique-item">
+                    <div class="form-check form-switch">
+                      <input class="form-check-input" type="checkbox" id="popup-dette-technique">
+                      <label class="form-check-label" for="popup-dette-technique">Dette technique</label>
+                    </div>
+                    <div class="form-text">Marquer la tâche comme dette technique.</div>
+                  </div>
+                </div>
               </div>
 
               <div class="task-section task-section-description">

--- a/test/js/config/constants.js
+++ b/test/js/config/constants.js
@@ -39,6 +39,24 @@ export const DEFAULT_URGENCES = ['Immédiate', 'Courte', 'Moyenne', 'Longue'];
 export const DEFAULT_IMPACTS = ['Critique', 'Important', 'Modéré', 'Mineur'];
 export const DEFAULT_PROJETS = [];
 
+// === TAXONOMIE NOUVELLE GÉNÉRATION ===
+export const PREVISIBILITE = [
+  { id: 'Imprévisible', libelle: 'Imprévisible', emoji: '⚡', couleur: '#ef4444', classe: 'previsibilite-imprevisible' },
+  { id: 'Prévisible', libelle: 'Prévisible', emoji: '🧭', couleur: '#0ea5e9', classe: 'previsibilite-previsible' }
+];
+
+export const DEFAULT_PREVISIBILITE = PREVISIBILITE.map(option => option.id);
+
+export const TYPE_TACHES = [
+  { id: 'Incident', libelle: 'Incident', emoji: '🚨', couleur: '#dc2626', classe: 'type-tache-incident' },
+  { id: 'Support', libelle: 'Support', emoji: '🛠️', couleur: '#2563eb', classe: 'type-tache-support' },
+  { id: 'MCO', libelle: 'MCO', emoji: '🔁', couleur: '#9333ea', classe: 'type-tache-mco' },
+  { id: 'Projet', libelle: 'Projet', emoji: '🚀', couleur: '#10b981', classe: 'type-tache-projet' },
+  { id: 'Overhead', libelle: 'Overhead', emoji: '📚', couleur: '#f59e0b', classe: 'type-tache-overhead' }
+];
+
+export const DEFAULT_TYPES_TACHES = TYPE_TACHES.map(option => option.id);
+
 // === CONFIGURATION GRIST ===
 export const TABLE_ID = "Ssir_principale_task";
 
@@ -51,6 +69,7 @@ export const REQUIRED_COLUMNS = [
 
 export const OPTIONAL_COLUMNS = [
   'date_debut', 'date_echeance', 'jalons', 'reference',
+  'previsibilite', 'type_tache', 'temps_estime_heures', 'est_dette_technique',
   // Colonnes de prod actives
   'type_tache_id', 'priorite', 'historique_statuts', 'datenow',
   'str_statut', 'str_urgence', 'str_qui', 'str_bureau', 'str_impact',

--- a/test/js/core/KanbanManager.js
+++ b/test/js/core/KanbanManager.js
@@ -11,6 +11,7 @@ import { ModalManager } from '../managers/ModalManager.js';
 import { HistoryManager } from '../managers/HistoryManager.js';
 import { FilterManager } from '../managers/FilterManager.js';
 import { ViewManager } from '../managers/ViewManager.js';
+import { JalonManager } from '../managers/JalonManager.js';
 
 // Importation du gestionnaire Grist
 import { GristManager } from '../managers/GristManager.js';
@@ -34,6 +35,7 @@ export class KanbanManager {
     this.historyManager = null;
     this.filterManager = null;
     this.viewManager = null;
+    this.jalonManager = null;
     
     // �tat des donn�es
     this.currentRecords = [];
@@ -137,7 +139,10 @@ export class KanbanManager {
     // 5. Gestionnaire de filtres
     this.filterManager = new FilterManager(this);
 
-    // 6. Gestionnaire de vues et de rendu
+    // 6. Gestionnaire des jalons (doit être initialisé après ModalManager)
+    this.jalonManager = new JalonManager(this);
+
+    // 7. Gestionnaire de vues et de rendu
     this.viewManager = new ViewManager(this);
 
     console.log('KanbanManager: Gestionnaires initialisés');

--- a/test/js/managers/GristManager.js
+++ b/test/js/managers/GristManager.js
@@ -314,11 +314,19 @@ export class GristManager {
     this.isUpdating = true;
 
     try {
+      const existingRecord = recordId
+        ? this.currentRecords.find(r => r.id === recordId) || null
+        : null;
+
+      if (recordId && !existingRecord) {
+        this.logger.warn(`Enregistrement ${recordId} introuvable dans le cache local - utilisation des données fournies uniquement`);
+      }
+
       // Valider les données
-      this.validateRecordData(recordData);
+      this.validateRecordData(recordData, recordId);
 
       // Préparer les données pour Grist
-      const gristData = this.prepareDataForGrist(recordData);
+      const gristData = this.prepareDataForGrist(recordData, existingRecord);
       const gristApi = this.getGristApi();
 
       let result;
@@ -401,20 +409,30 @@ export class GristManager {
    * Valide les données d'un enregistrement
    * @param {object} recordData - Données à valider
    */
-  validateRecordData(recordData) {
+  validateRecordData(recordData, recordId = null) {
     if (!recordData || typeof recordData !== 'object') {
       throw new Error('Données d\'enregistrement invalides');
     }
-    
+
+    const existingRecord = recordId ? this.currentRecords.find(r => r.id === recordId) : null;
+
+    const titreToValidate = recordData.titre !== undefined
+      ? recordData.titre
+      : existingRecord?.titre;
+
+    const statutToValidate = recordData.statut !== undefined
+      ? recordData.statut
+      : existingRecord?.statut;
+
     // Vérifier les champs requis
-    if (!recordData.titre || !recordData.titre.trim()) {
+    if (!titreToValidate || !titreToValidate.trim()) {
       throw new Error('Le titre est obligatoire');
     }
-    
-    if (!recordData.statut || !recordData.statut.trim()) {
+
+    if (!statutToValidate || !statutToValidate.trim()) {
       throw new Error('Le statut est obligatoire');
     }
-    
+
     // Valider le format des listes
     if (recordData.bureau && !Array.isArray(recordData.bureau)) {
       throw new Error('Le format du champ bureau est invalide');
@@ -436,30 +454,133 @@ export class GristManager {
   
   /**
    * Prépare les données pour l'envoi à Grist
-   * @param {object} recordData - Données source
+   * @param {object} recordData - Données source à appliquer
+   * @param {object|null} existingRecord - Enregistrement existant (pour les mises à jour partielles)
    * @returns {object} Données formatées pour Grist
    */
-  prepareDataForGrist(recordData) {
+  prepareDataForGrist(recordData, existingRecord = null) {
     const gristData = {};
-    
+
     // Copier les champs simples
-    const simpleFields = ['titre', 'description', 'statut', 'projet', 'urgence', 'impact', 'notes'];
-    
+    const simpleFields = [
+      'titre',
+      'description',
+      'statut',
+      'projet',
+      'urgence',
+      'impact',
+      'notes',
+      'reference',
+      'statut_precedent'
+    ];
+
+    const alwaysIncludedFields = new Set(['titre', 'description', 'statut', 'projet', 'urgence', 'impact', 'notes']);
+
     simpleFields.forEach(field => {
-      if (recordData.hasOwnProperty(field)) {
-        gristData[field] = recordData[field] || null;
+      const hasValue = Object.prototype.hasOwnProperty.call(recordData, field);
+      const shouldFallback = !hasValue && alwaysIncludedFields.has(field) && existingRecord;
+
+      if (!hasValue && !shouldFallback) {
+        return;
       }
+
+      const sourceValue = hasValue
+        ? recordData[field]
+        : existingRecord[field];
+
+      if (!alwaysIncludedFields.has(field) && !this.availableColumns.has(field)) {
+        return;
+      }
+
+      gristData[field] = sourceValue || null;
     });
-    
+
     // Traiter les listes (bureau, qui)
-    if (recordData.bureau) {
-      gristData.bureau = Array.isArray(recordData.bureau) ? recordData.bureau : ['L'];
+    const formatListField = (value) => {
+      if (!value) {
+        return ['L'];
+      }
+      if (Array.isArray(value)) {
+        const normalized = value.filter(Boolean);
+        if (normalized.length === 0) {
+          return ['L'];
+        }
+        if (normalized[0] === 'L') {
+          return ['L', ...normalized.slice(1)];
+        }
+        return ['L', ...normalized];
+      }
+      return ['L'];
+    };
+
+    const bureauValue = Object.prototype.hasOwnProperty.call(recordData, 'bureau')
+      ? recordData.bureau
+      : existingRecord?.bureau;
+    if (typeof bureauValue !== 'undefined') {
+      gristData.bureau = formatListField(bureauValue);
     }
-    
-    if (recordData.qui) {
-      gristData.qui = Array.isArray(recordData.qui) ? recordData.qui : ['L'];
+
+    const quiValue = Object.prototype.hasOwnProperty.call(recordData, 'qui')
+      ? recordData.qui
+      : existingRecord?.qui;
+    if (typeof quiValue !== 'undefined') {
+      gristData.qui = formatListField(quiValue);
     }
-    
+
+    // Champs JSON/texte optionnels
+    if (recordData.hasOwnProperty('historique_statuts') && this.availableColumns.has('historique_statuts')) {
+      gristData.historique_statuts = recordData.historique_statuts || null;
+    }
+
+    if (recordData.hasOwnProperty('jalons') && this.availableColumns.has('jalons')) {
+      const jalonsValue = recordData.jalons;
+      if (jalonsValue === null) {
+        gristData.jalons = null;
+      } else if (typeof jalonsValue === 'string') {
+        gristData.jalons = jalonsValue;
+      } else {
+        const normalized = jalonsValue || { jalons: [] };
+        gristData.jalons = JSON.stringify(normalized);
+      }
+    }
+
+    // Champs de taxonomie optionnels
+    if (recordData.hasOwnProperty('previsibilite') && this.availableColumns.has('previsibilite')) {
+      gristData.previsibilite = recordData.previsibilite || null;
+    }
+
+    if (recordData.hasOwnProperty('type_tache') && this.availableColumns.has('type_tache')) {
+      gristData.type_tache = recordData.type_tache || null;
+    }
+
+    if (recordData.hasOwnProperty('temps_estime_heures') && this.availableColumns.has('temps_estime_heures')) {
+      const estimatedValue = recordData.temps_estime_heures;
+      if (estimatedValue === null || (typeof estimatedValue === 'string' && estimatedValue.trim() === '')) {
+        gristData.temps_estime_heures = null;
+      } else {
+        const numericValue = Number(estimatedValue);
+        gristData.temps_estime_heures = Number.isFinite(numericValue) ? numericValue : null;
+      }
+    }
+
+    if (recordData.hasOwnProperty('est_dette_technique') && this.availableColumns.has('est_dette_technique')) {
+      const detteValue = recordData.est_dette_technique;
+      if (detteValue === null || typeof detteValue === 'undefined') {
+        gristData.est_dette_technique = null;
+      } else if (typeof detteValue === 'string') {
+        const normalized = detteValue.trim().toLowerCase();
+        if (!normalized) {
+          gristData.est_dette_technique = null;
+        } else {
+          gristData.est_dette_technique = ['1', 'true', 'oui', 'yes'].includes(normalized);
+        }
+      } else if (typeof detteValue === 'number') {
+        gristData.est_dette_technique = detteValue !== 0;
+      } else {
+        gristData.est_dette_technique = Boolean(detteValue);
+      }
+    }
+
     // 🔧 CORRECTION: Traiter strategie_id selon le schema Grist (Reference)
     if (recordData.strategie_id) {
       // Si c'est déjà au format Grist ["L", ID], conserver tel quel
@@ -486,10 +607,12 @@ export class GristManager {
     }
     
     // Ajouter les métadonnées si les colonnes existent
-    if (this.availableColumns.has('date_derniere_maj')) {
+    if (recordData.hasOwnProperty('date_derniere_maj')) {
+      gristData.date_derniere_maj = recordData.date_derniere_maj;
+    } else if (this.availableColumns.has('date_derniere_maj')) {
       gristData.date_derniere_maj = new Date().toISOString();
     }
-    
+
     return gristData;
   }
   

--- a/test/js/managers/ModalManager.js
+++ b/test/js/managers/ModalManager.js
@@ -15,7 +15,7 @@ import {
   confirmAction
 } from '../utils/dom.js';
 
-import { TABLE_ID } from '../config/constants.js';
+import { TABLE_ID, PREVISIBILITE, TYPE_TACHES, DEFAULT_PREVISIBILITE, DEFAULT_TYPES_TACHES } from '../config/constants.js';
 import { getUserActionManager } from '../utils/UserActionManager.js';
 import { createModuleLogger } from '../utils/LoggerManager.js';
 import { referenceManager } from '../utils/ReferenceManager.js';
@@ -1019,12 +1019,16 @@ export class ModalManager {
     // Liste des champs à vérifier
     const fieldIds = [
       'popup-titre',
-      'popup-description', 
+      'popup-description',
       'popup-urgence',
       'popup-impact',
+      'popup-previsibilite',
+      'popup-type-tache',
+      'popup-temps-estime',
       'popup-date-debut',
       'popup-date-echeance',
-      'popup-projet'
+      'popup-projet',
+      'popup-dette-technique'
     ];
     
     fieldIds.forEach(fieldId => {
@@ -1139,7 +1143,25 @@ export class ModalManager {
     // Urgence et Impact
     setFieldValue('popup-urgence', task.urgence || '');
     setFieldValue('popup-impact', task.impact || '');
-    
+
+    const resolvedPrevisibilite = this.resolvePrevisibiliteValue(task.previsibilite, this.isNewTask);
+    setFieldValue('popup-previsibilite', resolvedPrevisibilite);
+
+    const resolvedTypeTache = this.resolveTypeTacheValue(task.type_tache, this.isNewTask);
+    setFieldValue('popup-type-tache', resolvedTypeTache);
+
+    const normalizedHours = this.normalizeEstimatedHoursValue(task.temps_estime_heures);
+    const estimatedInput = document.getElementById('popup-temps-estime');
+    if (estimatedInput) {
+      estimatedInput.value = this.formatEstimatedHoursForInput(normalizedHours);
+    }
+
+    const debtCheckbox = document.getElementById('popup-dette-technique');
+    if (debtCheckbox) {
+      const normalizedDebt = this.normalizeTechnicalDebtValue(task.est_dette_technique);
+      debtCheckbox.checked = normalizedDebt === true;
+    }
+
     // Priorité calculée automatiquement
     const prioriteCalculee = this.calculatePriorite(task.urgence || '', task.impact || '');
     setFieldValue('popup-priorite-calculee', prioriteCalculee);
@@ -1466,6 +1488,120 @@ export class ModalManager {
     return gristFormat;
   }
 
+  getPrevisibiliteOptions() {
+    const options = this.kanban?.gristOptions?.previsibilite || this.kanban?.gristOptions?.previsibilites;
+    if (Array.isArray(options) && options.length > 0) {
+      return options.slice();
+    }
+    return DEFAULT_PREVISIBILITE.slice();
+  }
+
+  getTypeTacheOptions() {
+    const options = this.kanban?.gristOptions?.type_tache || this.kanban?.gristOptions?.type_taches || this.kanban?.gristOptions?.types;
+    if (Array.isArray(options) && options.length > 0) {
+      return options.slice();
+    }
+    return DEFAULT_TYPES_TACHES.slice();
+  }
+
+  resolvePrevisibiliteValue(currentValue, shouldDefault = false) {
+    if (typeof currentValue === 'string' && currentValue.trim()) {
+      return currentValue.trim();
+    }
+    if (!shouldDefault) {
+      return '';
+    }
+    const options = this.getPrevisibiliteOptions();
+    return options.length > 0 ? options[0] : '';
+  }
+
+  resolveTypeTacheValue(currentValue, shouldDefault = false) {
+    if (typeof currentValue === 'string' && currentValue.trim()) {
+      return currentValue.trim();
+    }
+    if (!shouldDefault) {
+      return '';
+    }
+    const options = this.getTypeTacheOptions();
+    return options.length > 0 ? options[0] : '';
+  }
+
+  normalizeChoiceValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return null;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+    return String(value).trim() || null;
+  }
+
+  normalizeTechnicalDebtValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return null;
+    }
+    if (typeof value === 'boolean') {
+      return value;
+    }
+    if (typeof value === 'number') {
+      return value !== 0;
+    }
+    if (typeof value === 'string') {
+      const normalized = value.trim().toLowerCase();
+      if (!normalized) {
+        return null;
+      }
+      if (['true', '1', 'oui', 'yes', 'on', 'vrai'].includes(normalized)) {
+        return true;
+      }
+      if (['false', '0', 'non', 'no', 'off', 'faux'].includes(normalized)) {
+        return false;
+      }
+    }
+    return Boolean(value);
+  }
+
+  normalizeEstimatedHoursValue(value) {
+    if (value === null || typeof value === 'undefined') {
+      return null;
+    }
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? Math.round(value * 100) / 100 : null;
+    }
+    if (typeof value === 'string') {
+      return this.parseEstimatedHours(value);
+    }
+    return null;
+  }
+
+  parseEstimatedHours(rawValue) {
+    if (typeof rawValue !== 'string') {
+      return null;
+    }
+    const normalized = rawValue.replace(',', '.').trim();
+    if (!normalized) {
+      return null;
+    }
+    const numeric = Number(normalized);
+    if (!Number.isFinite(numeric)) {
+      return NaN;
+    }
+    return Math.round(numeric * 100) / 100;
+  }
+
+  formatEstimatedHoursForInput(value) {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      return '';
+    }
+    return String(value);
+  }
+
+  getEstimatedHoursInputValue() {
+    const input = document.getElementById('popup-temps-estime');
+    return input ? input.value || '' : '';
+  }
+
   collectFormData() {
     const data = {
       titre: getFieldValue('popup-titre').trim(),
@@ -1476,22 +1612,41 @@ export class ModalManager {
       bureau: getSelectedOptionsAsGristFormat('popup-bureau'),
       qui: getSelectedOptionsAsGristFormat('popup-qui'),
       strategie_id: this.collectStrategyData(), // Collecte spécialisée stratégies
-      jalons: this.kanban.jalonManager ? this.kanban.jalonManager.getJalonsForSave() : null
+      jalons: null,
+      previsibilite: null,
+      type_tache: null,
+      temps_estime_heures: null,
+      est_dette_technique: false
     };
-    
+
     this.logger.debug(`Collecting form data: ${data.titre || 'untitled'} (${data.statut})`);
-    
+
+    const jalonsFromManager = this.kanban.jalonManager ? this.kanban.jalonManager.getJalonsForSave() : null;
+    const jalonsFromField = getFieldValue('popup-jalons');
+    data.jalons = jalonsFromManager !== null ? jalonsFromManager : (jalonsFromField || null);
+
+    data.previsibilite = this.normalizeChoiceValue(getFieldValue('popup-previsibilite'));
+
+    data.type_tache = this.normalizeChoiceValue(getFieldValue('popup-type-tache'));
+
+    const estimatedRaw = this.getEstimatedHoursInputValue();
+    const parsedHours = this.parseEstimatedHours(estimatedRaw);
+    data.temps_estime_heures = Number.isNaN(parsedHours) ? null : parsedHours;
+
+    const detteCheckbox = document.getElementById('popup-dette-technique');
+    data.est_dette_technique = detteCheckbox ? Boolean(detteCheckbox.checked) : false;
+
     // CHAMP DESCRIPTION SUPPRIMÉ - Tous les commentaires sont maintenant dans notes.history
     // Le champ de saisie popup-description sert uniquement pour les nouveaux commentaires
-    
+
     // Date d'échéance
     if (this.kanban.datePickerManager) {
       data.date_echeance = this.kanban.datePickerManager.getDateForGrist();
     }
-    
+
     return data;
   }
-  
+
   /**
    * Prépare les données pour l'envoi à Grist
    * @param {object} taskData - Données de la tâche
@@ -1514,7 +1669,23 @@ export class ModalManager {
     if (!gristData.statut) {
       gristData.statut = 'Backlog';
     }
-    
+
+    if (Object.prototype.hasOwnProperty.call(gristData, 'previsibilite')) {
+      gristData.previsibilite = this.normalizeChoiceValue(gristData.previsibilite);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(gristData, 'type_tache')) {
+      gristData.type_tache = this.normalizeChoiceValue(gristData.type_tache);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(gristData, 'temps_estime_heures')) {
+      gristData.temps_estime_heures = this.normalizeEstimatedHoursValue(gristData.temps_estime_heures);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(gristData, 'est_dette_technique')) {
+      gristData.est_dette_technique = this.normalizeTechnicalDebtValue(gristData.est_dette_technique);
+    }
+
     // Assurer que les listes sont dans le bon format - SEULEMENT si elles sont vides ou invalides
     if (!Array.isArray(gristData.bureau)) {
       gristData.bureau = ['L'];
@@ -2528,7 +2699,12 @@ export class ModalManager {
       responsables = [],
       qui = [],
       projet = [],
-      projets = []
+      projets = [],
+      previsibilite = [],
+      previsibilites = [],
+      type_tache = [],
+      type_taches = [],
+      types = []
     } = this.kanban.gristOptions;
 
     const sanitizeList = (values) => {
@@ -2545,19 +2721,33 @@ export class ModalManager {
     const responsableOptions = sanitizeList(responsables.length ? responsables : qui);
     const projetOptions = sanitizeList(projet.length ? projet : projets);
 
+    let previsibiliteOptions = sanitizeList(previsibilite.length ? previsibilite : previsibilites);
+    if (previsibiliteOptions.length === 0) {
+      previsibiliteOptions = this.getPrevisibiliteOptions();
+    }
+
+    let typeTacheOptions = sanitizeList(type_tache.length ? type_tache : (type_taches.length ? type_taches : types));
+    if (typeTacheOptions.length === 0) {
+      typeTacheOptions = this.getTypeTacheOptions();
+    }
+
     // Mémoriser une copie normalisée pour les opérations locales (ajout projet, etc.)
     this.gristOptions = {
       bureau: bureauOptions,
       responsables: responsableOptions,
       projet: projetOptions,
       urgence: urgenceOptions,
-      impact: impactOptions
+      impact: impactOptions,
+      previsibilite: previsibiliteOptions.slice(),
+      type_tache: typeTacheOptions.slice()
     };
 
     // Peupler les selects
     populateSelect('popup-urgence', urgenceOptions, true);
     populateSelect('popup-impact', impactOptions, true);
     populateSelect('popup-projet', projetOptions, true);
+    populateSelect('popup-previsibilite', previsibiliteOptions, true, '-- Prévisibilité --');
+    populateSelect('popup-type-tache', typeTacheOptions, true, '-- Type de tâche --');
 
     // Peupler les cases à cocher
     this.logger.debug(`Populating options: ${bureauOptions.length} bureau, ${responsableOptions.length} responsables`);
@@ -2690,7 +2880,11 @@ export class ModalManager {
     // Reset selects multiples
     $('#popup-bureau').val(['L']);
     $('#popup-qui').val(['L']);
-    
+    $('#popup-previsibilite').val('');
+    $('#popup-type-tache').val('');
+    $('#popup-temps-estime').val('');
+    $('#popup-dette-technique').prop('checked', false);
+
     // Reset checkboxes
     $('#popup-bureau-checkboxes input, #popup-qui-checkboxes input').prop('checked', false);
     
@@ -2751,7 +2945,18 @@ export class ModalManager {
       displayError('Veuillez sélectionner au moins un bureau');
       return false;
     }
-    
+
+    const estimatedRaw = this.getEstimatedHoursInputValue();
+    const parsedHours = this.parseEstimatedHours(estimatedRaw);
+    if (Number.isNaN(parsedHours)) {
+      displayError('Le temps estimé doit être un nombre valide');
+      return false;
+    }
+    if (parsedHours !== null && parsedHours < 0) {
+      displayError('Le temps estimé ne peut pas être négatif');
+      return false;
+    }
+
     return true;
   }
   
@@ -2816,11 +3021,25 @@ export class ModalManager {
     // Comparer avec les données originales
     const currentData = this.collectFormData();
     
+    const currentPrevisibilite = this.normalizeChoiceValue(currentData.previsibilite);
+    const currentTypeTache = this.normalizeChoiceValue(currentData.type_tache);
+    const currentEstimatedHours = this.normalizeEstimatedHoursValue(currentData.temps_estime_heures);
+    const currentDebt = this.normalizeTechnicalDebtValue(currentData.est_dette_technique);
+
+    const originalPrevisibilite = this.normalizeChoiceValue(this.currentTask?.previsibilite);
+    const originalTypeTache = this.normalizeChoiceValue(this.currentTask?.type_tache);
+    const originalEstimatedHours = this.normalizeEstimatedHoursValue(this.currentTask?.temps_estime_heures);
+    const originalDebt = this.normalizeTechnicalDebtValue(this.currentTask?.est_dette_technique);
+
     return (
       currentData.titre !== (this.currentTask.titre || '') ||
       currentData.projet !== (this.currentTask.projet || '') ||
       currentData.urgence !== (this.currentTask.urgence || '') ||
-      currentData.impact !== (this.currentTask.impact || '')
+      currentData.impact !== (this.currentTask.impact || '') ||
+      currentPrevisibilite !== originalPrevisibilite ||
+      currentTypeTache !== originalTypeTache ||
+      currentEstimatedHours !== originalEstimatedHours ||
+      currentDebt !== originalDebt
       // Ajouter d'autres comparaisons selon les besoins
     );
   }
@@ -2914,10 +3133,10 @@ export class ModalManager {
     if (!oldData || !newData) return false;
     
     const relevantFields = [
-      'titre', 'statut', 'projet', 'urgence', 'impact', 'bureau', 'qui', 
-      'strategie_id', 'date_debut', 'date_echeance', 'jalons'
-    ];
-    
+      'titre', 'statut', 'projet', 'urgence', 'impact', 'bureau', 'qui',
+      'strategie_id', 'date_debut', 'date_echeance', 'jalons',
+      'previsibilite', 'type_tache', 'temps_estime_heures', 'est_dette_technique'
+    ];    
     // Filtrer les champs exclus
     const fieldsToCheck = relevantFields.filter(field => !excludeFields.includes(field));
     
@@ -2930,6 +3149,30 @@ export class ModalManager {
         const oldJalonsStr = typeof oldValue === 'string' ? oldValue : JSON.stringify(oldValue || []);
         const newJalonsStr = typeof newValue === 'string' ? newValue : JSON.stringify(newValue || []);
         if (oldJalonsStr !== newJalonsStr) {
+          return true;
+        }
+      }
+      // Comparaison spéciale pour les champs de choix simples
+      else if (field === 'previsibilite' || field === 'type_tache') {
+        const normalizedOld = this.normalizeChoiceValue(oldValue);
+        const normalizedNew = this.normalizeChoiceValue(newValue);
+        if (normalizedOld !== normalizedNew) {
+          return true;
+        }
+      }
+      // Comparaison spéciale pour les heures estimées
+      else if (field === 'temps_estime_heures') {
+        const normalizedOld = this.normalizeEstimatedHoursValue(oldValue);
+        const normalizedNew = this.normalizeEstimatedHoursValue(newValue);
+        if (normalizedOld !== normalizedNew) {
+          return true;
+        }
+      }
+      // Comparaison spéciale pour la dette technique
+      else if (field === 'est_dette_technique') {
+        const normalizedOld = this.normalizeTechnicalDebtValue(oldValue);
+        const normalizedNew = this.normalizeTechnicalDebtValue(newValue);
+        if (normalizedOld !== normalizedNew) {
           return true;
         }
       }


### PR DESCRIPTION
## Summary
- importer et initialiser le JalonManager dans le KanbanManager de production pour aligner la gestion des jalons avec l’environnement de test
- exposer la propriété jalonManager sur l’orchestrateur afin que la modale puisse charger et sauvegarder les jalons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69015be7d3c88331bdc7c89b48600d51