### PR TITLE
fix(SharedTaskModal): charger historique après affichage modale

### DIFF
--- a/kanbantest/js/components/SharedTaskModal.js
+++ b/kanbantest/js/components/SharedTaskModal.js
@@ -153,6 +153,11 @@ class SharedTaskModal {
         if (!this.datePicker && (window.flatpickr || typeof flatpickr !== 'undefined')) {
           this.initDatePicker();
         }
+
+        // Charger l'historique une fois la modale visible
+        if (this.currentTask) {
+          this.loadTaskHistory();
+        }
       });
 
       this.setupEventListeners();


### PR DESCRIPTION
Le DOM n'était pas prêt lors de l'appel dans populateForm(). Ajout du chargement dans shown.bs.modal pour s'assurer que les éléments sont disponibles.

https://claude.ai/code/session_015tho4hdJHwFxZB76JtMjPR